### PR TITLE
修复 Android 14+ 及部分 OEM 设备上的 NMEA/GNSS 监听器崩溃问题

### DIFF
--- a/geolocator_android/android/src/main/java/com/baseflow/geolocator/location/NmeaClient.java
+++ b/geolocator_android/android/src/main/java/com/baseflow/geolocator/location/NmeaClient.java
@@ -6,6 +6,7 @@ import android.annotation.TargetApi;
 import android.content.Context;
 import android.content.pm.PackageManager;
 import android.location.GnssStatus;
+import android.util.Log;
 import android.location.Location;
 import android.location.LocationManager;
 import android.location.OnNmeaMessageListener;
@@ -19,6 +20,7 @@ import java.util.Calendar;
 
 public class NmeaClient {
 
+  private static final String TAG = "FlutterGeolocator";
   public static final String NMEA_ALTITUDE_EXTRA = "geolocator_mslAltitude";
   public static final String GNSS_SATELLITE_COUNT_EXTRA = "geolocator_mslSatelliteCount";
   public static final String GNSS_SATELLITES_USED_IN_FIX_EXTRA = "geolocator_mslSatellitesUsedInFix";
@@ -74,24 +76,32 @@ public class NmeaClient {
     }
 
     if (locationOptions != null) {
-      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N && locationManager != null) {
-        if (context.checkSelfPermission(Manifest.permission.ACCESS_FINE_LOCATION)
-            == PackageManager.PERMISSION_GRANTED) {
-          locationManager.addNmeaListener(nmeaMessageListener, null);
-          locationManager.registerGnssStatusCallback(gnssCallback, null);
-          listenerAdded = true;
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N && locationManager != null) {
+            if (context.checkSelfPermission(Manifest.permission.ACCESS_FINE_LOCATION)
+                    == PackageManager.PERMISSION_GRANTED) {
+                try {
+                    locationManager.addNmeaListener(nmeaMessageListener, null);
+                    locationManager.registerGnssStatusCallback(gnssCallback, null);
+                    listenerAdded = true;
+                } catch (SecurityException e) {
+                    Log.e(TAG, "NMEA/GNSS listener registration failed (e.g. work profile, Android 14+): " + e.getMessage());
+                }
+            }
         }
-      }
     }
   }
 
   public void stop() {
     if (locationOptions != null) {
-      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N && locationManager != null) {
-        locationManager.removeNmeaListener(nmeaMessageListener);
-        locationManager.unregisterGnssStatusCallback(gnssCallback);
-        listenerAdded = false;
-      }
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N && locationManager != null) {
+            try {
+                locationManager.removeNmeaListener(nmeaMessageListener);
+                locationManager.unregisterGnssStatusCallback(gnssCallback);
+            } catch (Exception e) {
+                Log.w(TAG, "NMEA/GNSS listener removal failed: " + e.getMessage());
+            }
+            listenerAdded = false;
+        }
     }
   }
 
@@ -118,7 +128,6 @@ public class NmeaClient {
 
       if (locationOptions.isUseMSLAltitude()) {
         String[] tokens = lastNmeaMessage.split(",");
-        String type = tokens[0];
 
         // Parse altitude above sea level, Detailed description of NMEA string here
         // http://aprs.gids.nl/nmea/#gga

--- a/geolocator_android/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/geolocator_android/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,5 +3,5 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-all.zip
 

--- a/geolocator_android/example/android/settings.gradle
+++ b/geolocator_android/example/android/settings.gradle
@@ -18,7 +18,7 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "8.7.0" apply false
+    id "com.android.application" version "8.9.1" apply false
 }
 
 include ":app"


### PR DESCRIPTION
Fix NMEA/GNSS listener crash on Android 14+ and some OEM devices Problem

<img width="2220" height="912" alt="image" src="https://github.com/user-attachments/assets/f0259eba-30c5-4bf9-a841-322e7aa91316" />


*List at least one fixed issue.*

## Pre-launch Checklist

- [x] I made sure the project builds.
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is does not need version changes.
- [x] I updated `CHANGELOG.md` to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I rebased onto `main`.
- [x] I added new tests to check the change I am making, or this PR does not need tests.
- [x] I made sure all existing and new tests are passing.
- [x] I ran `dart format .` and committed any changes.
- [x] I ran `flutter analyze` and fixed any errors.

<!-- References -->
[Contributor Guide]: https://github.com/Baseflow/flutter-geolocator/blob/master/CONTRIBUTING.md
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
